### PR TITLE
update readme urls and docker file go 1.81 -> 1.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cross-compiling [`zk`](https://github.com/mickael-menu/zk) with Docker
+# Cross-compiling [`zk`](https://github.com/zk-org/zk) with Docker
 
 Largely inspired by [dh1tw](https://dh1tw.de/2019/12/cross-compiling-golang-cgo-projects/) and [remoteAudio-xcompile](https://github.com/dh1tw/remoteAudio-xcompile).
 
@@ -7,18 +7,18 @@ Largely inspired by [dh1tw](https://dh1tw.de/2019/12/cross-compiling-golang-cgo-
 You can compile the `zk` source code directly from the source code directory. As example, for compiling the binary for linux/arm64 you have to execute the following command:
 
 ```sh
-docker run --rm -v "$PWD":/usr/src/zk -w /usr/src/zk mickaelmenu/zk-xcompile:linux-arm64 /bin/bash -c './go build'
+docker run --rm -v "$PWD":/usr/src/zk -w /usr/src/zk zk-org/zk-xcompile:linux-arm64 /bin/bash -c './go build'
 ```
 
 ## Releasing changes
 
 ```sh
-docker build -t mickaelmenu/zk-xcompile:linux-amd64 ./linux-amd64
-docker push mickaelmenu/zk-xcompile:linux-amd64
+docker build -t zk-org/zk-xcompile:linux-amd64 ./linux-amd64
+docker push zk-org/zk-xcompile:linux-amd64
 
-docker build -t mickaelmenu/zk-xcompile:linux-arm64 ./linux-arm64
-docker push mickaelmenu/zk-xcompile:linux-arm64
+docker build -t zk-org/zk-xcompile:linux-arm64 ./linux-arm64
+docker push zk-org/zk-xcompile:linux-arm64
 
-docker build -t mickaelmenu/zk-xcompile:linux-i386 ./linux-i386
-docker push mickaelmenu/zk-xcompile:linux-i386
+docker build -t zk-org/zk-xcompile:linux-i386 ./linux-i386
+docker push zk-org/zk-xcompile:linux-i386
 ```

--- a/linux-amd64/Dockerfile
+++ b/linux-amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.21
 LABEL os=linux
 LABEL arch=amd64
 

--- a/linux-arm64/Dockerfile
+++ b/linux-arm64/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.21
 LABEL os=linux
 LABEL arch=arm64
 

--- a/linux-i386/Dockerfile
+++ b/linux-i386/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.21
 LABEL os=linux
 LABEL arch=i386
 


### PR DESCRIPTION
As stated in title. 

In preparation for zk release 0.14.1