### PR TITLE
update docker images to go 1.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,39 @@
-# Cross-compiling [`zk`](https://github.com/mickael-menu/zk) with Docker
+# Cross-compiling [`zk`](https://github.com/zk-org/zk) with Docker
 
-Largely inspired by [dh1tw](https://dh1tw.de/2019/12/cross-compiling-golang-cgo-projects/) and [remoteAudio-xcompile](https://github.com/dh1tw/remoteAudio-xcompile).
+Largely inspired by
+[dh1tw](https://dh1tw.de/2019/12/cross-compiling-golang-cgo-projects/) and
+[remoteAudio-xcompile](https://github.com/dh1tw/remoteAudio-xcompile).
 
 ## How to invoke?
 
-You can compile the `zk` source code directly from the source code directory. As example, for compiling the binary for linux/arm64 you have to execute the following command:
+You can compile the `zk` source code directly from the source code directory. As
+example, for compiling the binary for linux/arm64 you have to execute the
+following command:
 
 ```sh
-docker run --rm -v "$PWD":/usr/src/zk -w /usr/src/zk mickaelmenu/zk-xcompile:linux-arm64 /bin/bash -c './go build'
+docker run --rm -v "$PWD":/usr/src/zk -w /usr/src/zk tjex/zk-xcompile:linux-arm64 /bin/bash -c './go build'
 ```
+
+In the case of [`zk`](https://github.com/zk-org/zk) itself, this call is already set in the `Makefile`,
+e.g. `make dist-linux-amd64`.
+
+More detail is documented here on
+[Golang's docker hub](https://hub.docker.com/_/golang).
 
 ## Releasing changes
 
+At time of writing (2024-05-18), Docker is soon to deprecate building with
+`docker build`, and is asking users to transition to `docker buildx build`.
+
+Tag signature: `<user>/<docker_hub_repo>:<os>-<arch>`
+
 ```sh
-docker build -t mickaelmenu/zk-xcompile:linux-amd64 ./linux-amd64
-docker push mickaelmenu/zk-xcompile:linux-amd64
+docker buildx build -t tjex/zk-xcompile:linux-amd64 ./linux-amd64
+docker push tjex/zk-xcompile:linux-amd64
 
-docker build -t mickaelmenu/zk-xcompile:linux-arm64 ./linux-arm64
-docker push mickaelmenu/zk-xcompile:linux-arm64
+docker buildx build -t tjex/zk-xcompile:linux-arm64 ./linux-arm64
+docker push tjex/zk-xcompile:linux-arm64
 
-docker build -t mickaelmenu/zk-xcompile:linux-i386 ./linux-i386
-docker push mickaelmenu/zk-xcompile:linux-i386
+docker buildx build -t tjex/zk-xcompile:linux-i386 ./linux-i386
+docker push tjex/zk-xcompile:linux-i386
 ```

--- a/linux-amd64/Dockerfile
+++ b/linux-amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM --platform=linux/amd64 golang:1.21
 LABEL os=linux
 LABEL arch=amd64
 
@@ -7,7 +7,7 @@ ENV GOARCH=amd64
 ENV CGO_ENABLED=1
 ENV CC=gcc
 
-RUN apt update \
- && apt install -y --no-install-recommends \
-        pkg-config \
- && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+&& apt-get upgrade \
+&& apt-get install -y --no-install-recommends pkg-config \
+&& rm -rf /var/lib/apt/lists/*

--- a/linux-arm64/Dockerfile
+++ b/linux-arm64/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM --platform=linux/arm64 golang:1.21
 LABEL os=linux
 LABEL arch=arm64
 

--- a/linux-i386/Dockerfile
+++ b/linux-i386/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM --platform=linux/386 golang:1.21
 LABEL os=linux
 LABEL arch=i386
 


### PR DESCRIPTION
Updated docker images for docker 1.21, which only needed an explicit `--platform` flag, on my end at least.

Even if this isn't strictly required for bug free builds on other machines, it doesn't hurt to include.

Added extra info to readme and change urls to latest images (didn't get replies on #3, so I just went ahead and put them up myself)

Also using `apt-get` instead of `apt` in `amd64` image.
