### PR TITLE
add missing -y flag

### DIFF
--- a/linux-amd64/Dockerfile
+++ b/linux-amd64/Dockerfile
@@ -8,7 +8,7 @@ ENV CGO_ENABLED=1
 ENV CC=gcc
 
 RUN apt-get update \
-&& apt-get upgrade \
+&& apt-get upgrade -y \
 && apt-get install -y --no-install-recommends pkg-config \
 && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The -y flag was missing on apt upgrade, so the build started to fail now as there was something to update.